### PR TITLE
Upgraded Archetype Dependency Versions

### DIFF
--- a/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-build/pom.xml
+++ b/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-build/pom.xml
@@ -44,9 +44,17 @@
 
                 <executions>
                     <execution>
+                        <id>package-modl</id>
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>install-modl</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>post</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-build/pom.xml
+++ b/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-build/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.0</version>
 
                 <executions>
                     <execution>
@@ -83,7 +83,7 @@
                     <moduleName>${project.parent.name}</moduleName>
                     <moduleDescription>${project.description}</moduleDescription>
                     <moduleVersion>${version}</moduleVersion>
-                    <requiredIgnitionVersion>8.0.0</requiredIgnitionVersion>
+                    <requiredIgnitionVersion>8.1.33</requiredIgnitionVersion>
 
                     <hooks>
                         <hook>

--- a/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-client/pom.xml
+++ b/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-client/pom.xml
@@ -67,8 +67,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/client/ClientHook.java
+++ b/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/client/ClientHook.java
@@ -3,12 +3,11 @@ package ${package}.client;
 import com.inductiveautomation.ignition.client.model.ClientContext;
 import com.inductiveautomation.ignition.common.licensing.LicenseState;
 import com.inductiveautomation.vision.api.client.AbstractClientModuleHook;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.inductiveautomation.ignition.common.util.LoggerEx;
 
 public class ClientHook extends AbstractClientModuleHook {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final LoggerEx logger = LoggerEx.newBuilder().build(getClass());
 
     @Override
     public void startup(ClientContext context, LicenseState activationState) throws Exception {

--- a/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-common/pom.xml
+++ b/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-common/pom.xml
@@ -29,8 +29,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-designer/pom.xml
+++ b/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-designer/pom.xml
@@ -64,8 +64,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-designer/src/main/java/designer/DesignerHook.java
+++ b/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-designer/src/main/java/designer/DesignerHook.java
@@ -3,12 +3,11 @@ package ${package}.designer;
 import com.inductiveautomation.ignition.common.licensing.LicenseState;
 import com.inductiveautomation.ignition.designer.model.AbstractDesignerModuleHook;
 import com.inductiveautomation.ignition.designer.model.DesignerContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.inductiveautomation.ignition.common.util.LoggerEx;
 
 public class DesignerHook extends AbstractDesignerModuleHook {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final LoggerEx logger = LoggerEx.newBuilder().build(getClass());
 
     @Override
     public void startup(DesignerContext context, LicenseState activationState) throws Exception {

--- a/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-gateway/pom.xml
+++ b/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-gateway/pom.xml
@@ -37,8 +37,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-gateway/src/main/java/GatewayHook.java
+++ b/client-designer-gateway-archetype/src/main/resources/archetype-resources/__rootArtifactId__-gateway/src/main/java/GatewayHook.java
@@ -3,12 +3,11 @@ package ${package};
 import com.inductiveautomation.ignition.common.licensing.LicenseState;
 import com.inductiveautomation.ignition.gateway.model.AbstractGatewayModuleHook;
 import com.inductiveautomation.ignition.gateway.model.GatewayContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.inductiveautomation.ignition.common.util.LoggerEx;
 
 public class GatewayHook extends AbstractGatewayModuleHook {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final LoggerEx logger = LoggerEx.newBuilder().build(getClass());
 
     @Override
     public void setup(GatewayContext gatewayContext) {

--- a/client-designer-gateway-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/client-designer-gateway-archetype/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
     <description>${rootArtifactId} Ignition Module</description>
 
     <properties>
-        <ignition-sdk-version>8.0.1</ignition-sdk-version>
+        <ignition-sdk-version>8.1.33</ignition-sdk-version>
     </properties>
 
     <modules>

--- a/opc-ua-device-archetype/src/main/resources/archetype-resources/__rootArtifactId__-build/pom.xml
+++ b/opc-ua-device-archetype/src/main/resources/archetype-resources/__rootArtifactId__-build/pom.xml
@@ -25,7 +25,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.0</version>
 
                 <executions>
                     <execution>
@@ -48,7 +48,7 @@
                     <moduleName>${project.parent.name}</moduleName>
                     <moduleDescription>${project.description}</moduleDescription>
                     <moduleVersion>${version}</moduleVersion>
-                    <requiredIgnitionVersion>8.0.0</requiredIgnitionVersion>
+                    <requiredIgnitionVersion>8.1.33</requiredIgnitionVersion>
 
                     <hooks>
                         <hook>

--- a/opc-ua-device-archetype/src/main/resources/archetype-resources/__rootArtifactId__-device/pom.xml
+++ b/opc-ua-device-archetype/src/main/resources/archetype-resources/__rootArtifactId__-device/pom.xml
@@ -45,8 +45,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/opc-ua-device-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/opc-ua-device-archetype/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
     <description>${rootArtifactId} Device Module</description>
 
     <properties>
-        <ignition-sdk-version>8.0.1</ignition-sdk-version>
+        <ignition-sdk-version>8.1.33</ignition-sdk-version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
     <properties>
         <maven.test.skip>true</maven.test.skip>
         <maven.version>3.0</maven.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
     </properties>

--- a/vision-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-build/pom.xml
+++ b/vision-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-build/pom.xml
@@ -30,13 +30,21 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.0</version>
 
                 <executions>
                     <execution>
+                        <id>package-modl</id>
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>install-modl</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>post</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -57,7 +65,7 @@
                     <moduleName>${project.parent.name}</moduleName>
                     <moduleDescription>${project.description}</moduleDescription>
                     <moduleVersion>${version}</moduleVersion>
-                    <requiredIgnitionVersion>8.0.0</requiredIgnitionVersion>
+                    <requiredIgnitionVersion>8.1.33</requiredIgnitionVersion>
 
                     <hooks>
                         <hook>

--- a/vision-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-client/pom.xml
+++ b/vision-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-client/pom.xml
@@ -29,8 +29,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/vision-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-designer/pom.xml
+++ b/vision-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-designer/pom.xml
@@ -43,8 +43,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/vision-component-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/vision-component-archetype/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
     <description>${rootArtifactId} Ignition Module</description>
 
     <properties>
-        <ignition-sdk-version>8.0.1</ignition-sdk-version>
+        <ignition-sdk-version>8.1.33</ignition-sdk-version>
     </properties>
 
     <modules>


### PR DESCRIPTION
- Upgraded default sdk to 8.1.33
- Set default java compile target to 17
- Changed SLF4J logger to LoggerEx